### PR TITLE
remove useless onEnd() call

### DIFF
--- a/javascript/src/live/helpers.js
+++ b/javascript/src/live/helpers.js
@@ -104,7 +104,6 @@ export function initFileRecorder(config, onAudioChunk, onEnd, filePath = "../dat
                 if (offset >= buffer.length) {
                     console.log(">>>>> Sent all audio data");
                     this.stop();
-                    onEnd();
                 }
             }, chunkDuration * 1000);
         },

--- a/typescript/src/live/helpers.ts
+++ b/typescript/src/live/helpers.ts
@@ -141,7 +141,6 @@ export function initFileRecorder(
         if (offset >= buffer.length) {
           console.log(">>>>> Sent all audio data");
           this.stop();
-          onEnd();
         }
       }, chunkDuration * 1000);
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the handling of the end of audio data processing, which may impact the timing of when recording sessions are signaled as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->