### PR TITLE
feat: add speech_threshold in the type definition

### DIFF
--- a/typescript/src/live/types.ts
+++ b/typescript/src/live/types.ts
@@ -15,6 +15,7 @@ export type StreamingConfig = {
 
   pre_processing?: {
     audio_enhancer?: boolean;
+    speech_threshold?: number;
   };
 
   realtime_processing?: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an optional speech threshold configuration parameter for audio streaming settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->