### PR TITLE
remove deprecated field

### DIFF
--- a/typescript/src/live/types.ts
+++ b/typescript/src/live/types.ts
@@ -23,7 +23,6 @@ export type StreamingConfig = {
   };
 
   realtime_processing?: {
-    words_accurate_timestamps?: boolean;
     custom_vocabulary?: boolean;
     custom_vocabulary_config?: {
       vocabulary: (Vocab | string)[];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated configuration options by removing the "words_accurate_timestamps" setting from streaming configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->