### PR TITLE
[GLA-2293] add receive_partial_transcripts to openapi

### DIFF
--- a/typescript/src/live/types.ts
+++ b/typescript/src/live/types.ts
@@ -46,9 +46,30 @@ export type StreamingConfig = {
     chapterization?: boolean;
   };
 
+  messages_config?: {
+    receive_partial_transcripts?: boolean;
+    receive_final_transcripts?: boolean;
+    receive_speech_events?: boolean;
+    receive_pre_processing_events?: boolean;
+    receive_realtime_processing_events?: boolean;
+    receive_post_processing_events?: boolean;
+    receive_acknowledgments?: boolean;
+    receive_errors?: boolean;
+    receive_lifecycle_events?: boolean;
+  };
+
   callback?: boolean;
   callback_config?: {
     url: string;
+    receive_partial_transcripts?: boolean;
+    receive_final_transcripts?: boolean;
+    receive_speech_events?: boolean;
+    receive_pre_processing_events?: boolean;
+    receive_realtime_processing_events?: boolean;
+    receive_post_processing_events?: boolean;
+    receive_acknowledgments?: boolean;
+    receive_errors?: boolean;
+    receive_lifecycle_events?: boolean;
   };
 };
 
@@ -57,7 +78,7 @@ export type Vocab = {
   intensity?: number;
   pronunciations?: string[];
   language?: string;
-}
+};
 
 export type Recorder = {
   start(): void;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced granular controls to choose which messages/events you receive in streaming and callback configurations. Options include partial/final transcripts, speech events, pre/realtime/post-processing events, acknowledgments, errors, and lifecycle events—letting you tailor notifications and reduce noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->