### PR TITLE
[FEA-1427] fix(vuln): bump nltk 3.9.4->3.10.0 in pipecat-bot

### DIFF
--- a/integrations-examples/pipecat-bot/uv.lock
+++ b/integrations-examples/pipecat-bot/uv.lock
@@ -830,7 +830,7 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.4"
+version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -838,9 +838,9 @@ dependencies = [
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/23/b94b11ae1498e2d8cd73deae0a1e9fc37c97df462b5d0fef6bfc63f2f07e/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4e/88ec3a9bd696ce7424dfe6a4e4282e42e15cfa77fddcd36c4e2e8d9b18df/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144 },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes URL-Encoded Path Traversal in NLTK by upgrading 3.9.4→3.10.0 in pipecat-bot integration example.

Linear: https://linear.app/gladia/issue/FEA-1427

Made with [Cursor](https://cursor.com)