### PR TITLE
fix(FEA-983): bump idna 3.10->3.18 in python/uv.lock

### DIFF
--- a/python/uv.lock
+++ b/python/uv.lock
@@ -159,13 +159,12 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2025-05-14T15:37:35.0Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2025-05-14T15:37:37.0Z" },
 ]
-
 [[package]]
 name = "iniconfig"
 version = "2.3.0"


### PR DESCRIPTION
## Summary

- Bumps `idna` from `3.10` to `3.18` in `python/uv.lock`
- Fixes CVE-2026-45409 (GHSA-65pc-fj4g-8rjx): specially crafted inputs to `idna.encode()` could cause a denial of service via significant CPU usage

## Linear

Closes https://linear.app/gladia/issue/FEA-983

Made with [Cursor](https://cursor.com)